### PR TITLE
Add magic number to region header, enforce checks

### DIFF
--- a/include/dmm.h
+++ b/include/dmm.h
@@ -3,8 +3,13 @@
 
 #include <stddef.h>
 
-void add_dmm_tests();
-void dmm_init();
+typedef void (DMM_PanicFn)(const char *message, const char *function,
+		const char *filename, size_t line, size_t automated);
+
+extern DMM_PanicFn *_dmm_panic;
+#define dmm_panic(message) _dmm_panic(message, __FUNCTION__, __FILE__, __LINE__, 0)
+
+void dmm_init(DMM_PanicFn *panic_fn);
 
 void dmm_add_memory_region(void *start, size_t length);
 
@@ -15,8 +20,9 @@ void *dmm_realloc(void *ptr, size_t size);
 #ifdef DMM_INTRUSIVE
 #define malloc(size) dmm_malloc(size)
 #define free(ptr) dmm_free(ptr)
-#define calloc(nmemb, size) dmm_calloc(nmemb, size)
 #define realloc(ptr, size) dmm_realloc(ptr, size)
 #endif
+
+void add_dmm_tests();
 
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -1,15 +1,19 @@
 #ifndef DMM_MAIN_H
 #define DMM_MAIN_H
 
-// REQUIREMENTS: Requires size_t (stddef.h).
+// REQUIREMENTS: Requires size_t (stddef.h), uint32_t (stdint.h).
 
 #include <stddef.h>
+#include <stdint.h>
+
+#define DMM_HEADER_MAGIC 0x99A3E7D6
 
 typedef void *(DMM_MallocFn)(size_t size);
 typedef void (DMM_FreeFn)(void *ptr);
 typedef void *(DMM_ReallocFn)(void *ptr, size_t size);
 
 typedef struct dmm_malloc_header_s {
+    uint32_t magic;
     size_t size;
     size_t used; // A bit space-inefficient, but means we only require one type.
     void *data;


### PR DESCRIPTION
This change requires that dmm_init() be called with a function pointer
that matches _flail_panic from the flail library. This will be called
whenever a region header has an incorrect magic number, as we can't
trust any memory locations from that point on.