### PR TITLE
Make DMM use instances for core functions

### DIFF
--- a/include/dmm.h
+++ b/include/dmm.h
@@ -1,5 +1,5 @@
-#ifndef DMM_H
-#define DMM_H
+#ifndef DMM__DMM_H
+#define DMM__DMM_H
 
 #include <stddef.h>
 
@@ -12,17 +12,11 @@ extern DMM_PanicFn *_dmm_panic;
 void dmm_init(DMM_PanicFn *panic_fn);
 
 void dmm_add_memory_region(void *start, size_t length);
-
 void *dmm_malloc(size_t size);
 void dmm_free(void *ptr);
 void *dmm_realloc(void *ptr, size_t size);
 
-#ifdef DMM_INTRUSIVE
-#define malloc(size) dmm_malloc(size)
-#define free(ptr) dmm_free(ptr)
-#define realloc(ptr, size) dmm_realloc(ptr, size)
-#endif
-
+// Tests
 void add_dmm_tests();
 
 #endif

--- a/include/dmm_instance.h
+++ b/include/dmm_instance.h
@@ -1,0 +1,11 @@
+#ifndef DMM__DMM_INSTANCE_H
+#define DMM__DMM_INSTANCE_H
+
+#include <stddef.h>
+
+void *dmm_instance_add_memory_region(void *instance, void *start, size_t length);
+void *dmm_instance_malloc(void *instance, size_t size);
+void dmm_instance_free(void *instance, void *ptr);
+void *dmm_instance_realloc(void *instance, void *ptr, size_t size);
+
+#endif

--- a/src/header.h
+++ b/src/header.h
@@ -1,0 +1,18 @@
+#ifndef DMM_HEADER_H
+#define DMM_HEADER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define DMM_HEADER_MAGIC 0x99A3E7D6
+#define DMM_UNASSIGNED_REGION NULL
+
+typedef struct dmm_malloc_header_s {
+    uint32_t magic;
+    size_t size;
+    size_t used; // A bit space-inefficient, but means we only require one type.
+    void *data;
+    struct dmm_malloc_header_s *next;
+} DMM_MallocHeader;
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,12 @@
+#include <dmm.h>
+#include <stddef.h>
+#include <string.h>
+#include "main.h"
+#include "header.h"
+
+DMM_PanicFn *_dmm_panic = NULL;
+
+void dmm_init(DMM_PanicFn *panic_fn)
+{
+    _dmm_panic = panic_fn;
+}

--- a/src/instance.c
+++ b/src/instance.c
@@ -1,0 +1,149 @@
+// REQUIREMENTS: Requires size_t (stddef.h); and memset() and memcpy() (string.h).
+
+#include <dmm.h>
+#include <dmm_instance.h>
+#include <stddef.h>
+#include <string.h>
+#include "main.h"
+#include "header.h"
+#include "instance.h"
+
+void *dmm_instance_add_memory_region(void *instance, void *start, size_t length)
+{
+    DMM_MallocHeader *header = (DMM_MallocHeader*)start;
+    header->magic = DMM_HEADER_MAGIC;
+    header->size = length - sizeof(DMM_MallocHeader);
+    header->used = 0;
+    header->data = (void*)(header + 1);
+    header->next = DMM_UNASSIGNED_REGION;
+
+    if (instance != DMM_UNASSIGNED_REGION && instance != NULL) {
+        DMM_MallocHeader *last = (DMM_MallocHeader *)instance;
+
+        while (1) {
+            if (last->magic != DMM_HEADER_MAGIC) {
+                dmm_panic("memory region header had invalid magic");
+            }
+
+            if (last->next == DMM_UNASSIGNED_REGION) {
+                last->next = header;
+                break;
+            }
+
+            last = last->next;
+        }
+    }
+
+    return (void *)header;
+}
+
+DMM_MallocHeader *dmm_instance_get_first_free_chunk(void *instance, size_t size)
+{
+    DMM_MallocHeader *chunk = (DMM_MallocHeader *)instance;
+    if (chunk == DMM_UNASSIGNED_REGION || chunk == NULL) {
+        return NULL;
+    }
+
+    while (1) {
+        if (chunk->magic != DMM_HEADER_MAGIC) {
+            dmm_panic("memory region header had invalid magic");
+        }
+
+        if ((chunk->size >= size) && (chunk->used == 0)) {
+            return chunk;
+        }
+
+        chunk = chunk->next;
+        if (chunk == DMM_UNASSIGNED_REGION) {
+            return NULL;
+        }
+    }
+
+    return NULL;
+}
+
+void *dmm_instance_malloc(void *instance, size_t size)
+{
+    DMM_MallocHeader *result = dmm_instance_get_first_free_chunk(instance, size);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    if (result->magic != DMM_HEADER_MAGIC) {
+        dmm_panic("memory region header had invalid magic");
+    }
+
+    // Calculate the size of the memory chunk after the allocated region.
+    size_t next_size = result->size - (size + sizeof(DMM_MallocHeader));
+
+    // Set the header to contain this region's exact size, and set it as used.
+    result->used = 1;
+    result->size = size;
+
+    // NOTE: dmm_malloc() zeroes memory, which isn't what most allocators do.
+    // Not sure if that violates the C standard or not, but *shrug*.
+    memset(result->data, 0, size);
+
+    // Create a new header after the data, if the remaining data size is
+    // large enough to fit the header.
+    if (next_size > 0) {
+        void *next = (void *)((size_t)(result + 1) + size);
+        DMM_MallocHeader *next_header = (DMM_MallocHeader*)next;
+        memset(next, 0, sizeof(DMM_MallocHeader));
+
+        next_header->magic = DMM_HEADER_MAGIC;
+        next_header->size = next_size;
+        next_header->used = 0;
+        next_header->data = (void*)(next_header + 1);
+        next_header->next = result->next;
+
+        // Set the header of this chunk to point to the new header.
+        result->next = next_header;
+    }
+
+    return result->data;
+}
+
+void dmm_instance_free(void *instance, void *ptr)
+{
+    (void)instance; // TODO: does this require an instance?
+    DMM_MallocHeader *header = (DMM_MallocHeader*)(ptr) - 1;
+    if (header->magic != DMM_HEADER_MAGIC) {
+        dmm_panic("memory region header had invalid magic");
+    }
+
+    header->used = 0;
+
+    // TODO: merge this chunk into the previous/next chunks if they are also
+    // marked as free.
+}
+
+// TODO: dmm_realloc() should attempt to resize existing chunk rather
+// than just allocating a new one and memcpy()ing.
+void *dmm_instance_realloc(void *instance, void *ptr, size_t size)
+{
+    DMM_MallocHeader *header;
+    void *new_ptr;
+    size_t min_size;
+
+    if (ptr == NULL) {
+        return dmm_malloc(size);
+    }
+
+    header = (DMM_MallocHeader*)(ptr) - 1;
+    if (header->magic != DMM_HEADER_MAGIC) {
+        dmm_panic("memory region header had invalid magic");
+    }
+
+    // ASSUMPTION: dmm_malloc() zeroes allocated memory.
+    new_ptr = dmm_malloc(size);
+    min_size = (size < header->size) ? size : header->size;
+
+    if (new_ptr == NULL) {
+        return NULL;
+    }
+
+    memcpy(new_ptr, ptr, min_size);
+
+    return new_ptr;
+}

--- a/src/instance.h
+++ b/src/instance.h
@@ -1,0 +1,10 @@
+#ifndef DMM_INSTANCE_H
+#define DMM_INSTANCE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "header.h"
+
+DMM_MallocHeader *dmm_instance_get_first_free_chunk(void *instance, size_t size);
+
+#endif

--- a/src/instance_test.c
+++ b/src/instance_test.c
@@ -1,0 +1,66 @@
+#include <ktest.h>
+#include <stddef.h>
+#include <dmm.h>
+#include <dmm_instance.h>
+#include "header.h"
+#include "instance.h"
+#include "instance_test.h"
+
+DMM_MallocHeader *test_instance = DMM_UNASSIGNED_REGION;
+
+size_t test_dmm_instance_add_region()
+{
+    TEST_HAS_ASSERTIONS();
+
+    size_t length = 128;
+
+    void *region = dmm_malloc(length);
+    TEST_ASSERT(region != NULL); // sanity check
+
+    void *result = dmm_instance_add_memory_region(test_instance, region, length);
+    TEST_ASSERT(result != DMM_UNASSIGNED_REGION);
+    TEST_ASSERT(result != NULL);
+    test_instance = result;
+
+    // Actually check the header
+    DMM_MallocHeader *header = (DMM_MallocHeader *)region;
+    TEST_ASSERT(header->size == length - sizeof(DMM_MallocHeader));
+    TEST_ASSERT(header->used == 0);
+    TEST_ASSERT(header->data == (void *)(header + 1));
+
+    TEST_ASSERTIONS_RETURN();
+}
+
+size_t test_dmm_instance_malloc()
+{
+    TEST_HAS_ASSERTIONS();
+
+    void *region = dmm_instance_malloc(test_instance, 10);
+    TEST_ASSERT(region != NULL);
+
+    DMM_MallocHeader *header = ((DMM_MallocHeader*)region) - 1;
+
+    TEST_ASSERT(header->size == 10);
+    TEST_ASSERT(header->used == 1);
+    TEST_ASSERT(header->data == region);
+
+    TEST_ASSERTIONS_RETURN();
+}
+
+size_t test_dmm_instance_free_sets_header()
+{
+    TEST_HAS_ASSERTIONS();
+
+    void *region = dmm_instance_malloc(test_instance, 10);
+    TEST_ASSERT(region != NULL);
+
+    DMM_MallocHeader *header = ((DMM_MallocHeader*)region) - 1;
+
+    TEST_ASSERT(header->used == 1);
+
+    dmm_instance_free(test_instance, region);
+
+    TEST_ASSERT(header->used == 0);
+
+    TEST_ASSERTIONS_RETURN();
+}

--- a/src/instance_test.h
+++ b/src/instance_test.h
@@ -1,0 +1,14 @@
+#ifndef DMM_INSTANCE_TEST_H
+#define DMM_INSTANCE_TEST_H
+
+#include <stddef.h>
+#include <dmm.h>
+#include <dmm_instance.h>
+#include "main.h"
+#include "instance.h"
+
+size_t test_dmm_instance_add_region();
+size_t test_dmm_instance_malloc();
+size_t test_dmm_instance_free_sets_header();
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,153 +1,42 @@
 // REQUIREMENTS: Requires size_t (stddef.h); and memset() and memcpy() (string.h).
 
 #include <dmm.h>
+#include <dmm_instance.h>
 #include <stddef.h>
 #include <string.h>
 #include "main.h"
+#include "header.h"
+#include "instance.h"
 
-DMM_PanicFn *_dmm_panic = NULL;
-DMM_MallocHeader *first = DMM_UNASSIGNED_REGION;
-
-void dmm_init(DMM_PanicFn *panic_fn)
-{
-    _dmm_panic = panic_fn;
-}
+DMM_MallocHeader *global_instance = DMM_UNASSIGNED_REGION;
 
 void dmm_add_memory_region(void *start, size_t length)
 {
-    DMM_MallocHeader *header = (DMM_MallocHeader*)start;
-    header->magic = DMM_HEADER_MAGIC;
-    header->size = length - sizeof(DMM_MallocHeader);
-    header->used = 0;
-    header->data = (void*)(header + 1);
-    header->next = DMM_UNASSIGNED_REGION;
+    void *result = dmm_instance_add_memory_region(global_instance, start, length);
 
-    if (first == DMM_UNASSIGNED_REGION) {
-        first = header;
-    } else {
-        DMM_MallocHeader *last = first;
-
-        while (1) {
-            if (last->magic != DMM_HEADER_MAGIC) {
-                dmm_panic("memory region header had invalid magic");
-            }
-
-            if (last->next == DMM_UNASSIGNED_REGION) {
-                last->next = header;
-                break;
-            }
-
-            last = last->next;
+    if (global_instance == DMM_UNASSIGNED_REGION || global_instance == NULL) {
+        if (result != DMM_UNASSIGNED_REGION && result != NULL) {
+            global_instance = result;
         }
     }
 }
 
 DMM_MallocHeader *dmm_get_first_free_chunk(size_t size)
 {
-    DMM_MallocHeader *chunk = first;
-    if (chunk == DMM_UNASSIGNED_REGION) {
-        return NULL;
-    }
-
-    while (1) {
-        if (chunk->magic != DMM_HEADER_MAGIC) {
-            dmm_panic("memory region header had invalid magic");
-        }
-
-        if ((chunk->size >= size) && (chunk->used == 0)) {
-            return chunk;
-        }
-
-        chunk = chunk->next;
-        if (chunk == DMM_UNASSIGNED_REGION) {
-            return NULL;
-        }
-    }
-
-    return NULL;
+    return dmm_instance_get_first_free_chunk(global_instance, size);
 }
 
 void *dmm_malloc(size_t size)
 {
-    DMM_MallocHeader *result = dmm_get_first_free_chunk(size);
-    if (result == NULL) {
-        return NULL;
-    }
-
-    if (result->magic != DMM_HEADER_MAGIC) {
-        dmm_panic("memory region header had invalid magic");
-    }
-
-    // Calculate the size of the memory chunk after the allocated region.
-    size_t next_size = result->size - (size + sizeof(DMM_MallocHeader));
-
-    // Set the header to contain this region's exact size, and set it as used.
-    result->used = 1;
-    result->size = size;
-
-    // NOTE: dmm_malloc() zeroes memory, which isn't what most allocators do.
-    // Not sure if that violates the C standard or not, but *shrug*.
-    memset(result->data, 0, size);
-
-    // Create a new header after the data, if the remaining data size is
-    // large enough to fit the header.
-    if (next_size > 0) {
-        void *next = (void *)((size_t)(result + 1) + size);
-        DMM_MallocHeader *next_header = (DMM_MallocHeader*)next;
-        memset(next, 0, sizeof(DMM_MallocHeader));
-
-        next_header->magic = DMM_HEADER_MAGIC;
-        next_header->size = next_size;
-        next_header->used = 0;
-        next_header->data = (void*)(next_header + 1);
-        next_header->next = result->next;
-
-        // Set the header of this chunk to point to the new header.
-        result->next = next_header;
-    }
-
-    return result->data;
+    return dmm_instance_malloc(global_instance, size);
 }
 
 void dmm_free(void *ptr)
 {
-    DMM_MallocHeader *header = (DMM_MallocHeader*)(ptr) - 1;
-    if (header->magic != DMM_HEADER_MAGIC) {
-        dmm_panic("memory region header had invalid magic");
-    }
-
-    header->used = 0;
-
-    // TODO: merge this chunk into the previous/next chunks if they are also
-    // marked as free.
+    dmm_instance_free(global_instance, ptr);
 }
 
-// TODO: dmm_realloc() should attempt to resize existing chunk rather
-// than just allocating a new one and memcpy()ing.
 void *dmm_realloc(void *ptr, size_t size)
 {
-    DMM_MallocHeader *header;
-    void *new_ptr;
-    size_t min_size;
-
-    if (ptr == NULL) {
-        return dmm_malloc(size);
-    }
-
-    header = (DMM_MallocHeader*)(ptr) - 1;
-    if (header->magic != DMM_HEADER_MAGIC) {
-        dmm_panic("memory region header had invalid magic");
-    }
-
-    // ASSUMPTION: dmm_malloc() zeroes allocated memory.
-    new_ptr = dmm_malloc(size);
-    min_size = (size < header->size) ? size : header->size;
-
-    if (new_ptr == NULL) {
-        return NULL;
-    }
-
-    memcpy(new_ptr, ptr, min_size);
-
-    return new_ptr;
+    return dmm_instance_realloc(global_instance, ptr, size);
 }

--- a/src/main.h
+++ b/src/main.h
@@ -5,22 +5,11 @@
 
 #include <stddef.h>
 #include <stdint.h>
-
-#define DMM_HEADER_MAGIC 0x99A3E7D6
+#include "header.h"
 
 typedef void *(DMM_MallocFn)(size_t size);
 typedef void (DMM_FreeFn)(void *ptr);
 typedef void *(DMM_ReallocFn)(void *ptr, size_t size);
-
-typedef struct dmm_malloc_header_s {
-    uint32_t magic;
-    size_t size;
-    size_t used; // A bit space-inefficient, but means we only require one type.
-    void *data;
-    struct dmm_malloc_header_s *next;
-} DMM_MallocHeader;
-
-#define DMM_UNASSIGNED_REGION NULL
 
 typedef struct dmm_memory_manager_functions_s {
     DMM_MallocFn *malloc;

--- a/src/main_test.c
+++ b/src/main_test.c
@@ -2,6 +2,7 @@
 #include <stddef.h>
 #include <dmm.h>
 #include "main.h"
+#include "main_test.h"
 
 size_t test_dmm_malloc()
 {
@@ -35,10 +36,4 @@ size_t test_dmm_free_sets_header()
     TEST_ASSERT(header->used == 0);
 
     TEST_ASSERTIONS_RETURN();
-}
-
-void add_dmm_tests()
-{
-    TEST(dmm_malloc);
-    TEST(dmm_free_sets_header);
 }

--- a/src/main_test.h
+++ b/src/main_test.h
@@ -1,0 +1,11 @@
+#ifndef DMM_MAIN_TEST_H
+#define DMM_MAIN_TEST_H
+
+#include <stddef.h>
+#include <dmm.h>
+#include "main.h"
+
+size_t test_dmm_malloc();
+size_t test_dmm_free_sets_header();
+
+#endif

--- a/src/test.c
+++ b/src/test.c
@@ -1,0 +1,17 @@
+#include <ktest.h>
+#include <stdint.h>
+#include <stddef.h>
+#include "main_test.h"
+#include "instance_test.h"
+
+void add_dmm_tests()
+{
+    // Global instance tests
+    TEST(dmm_malloc);
+    TEST(dmm_free_sets_header);
+
+    // Local instance tests
+    TEST(dmm_instance_add_region);
+    TEST(dmm_instance_malloc);
+    TEST(dmm_instance_free_sets_header);
+}


### PR DESCRIPTION
This PR:

* Renames core functions from `dmm_*` to `dmm_instance_*`, make all these functions take an `instance` variable pointing to the first region entry
* Adds wrappers under the previous (non-`instance`) names that use a global instance variable 
* Adds tests for the `instance` class of functions, using a test instance
   * This also adds a test for the `dmm_instance_add_memory_region()` function, which the test for was removed previously
