### PR TITLE
Add an allocate-the-universe test

### DIFF
--- a/src/header.h
+++ b/src/header.h
@@ -6,11 +6,13 @@
 
 #define DMM_HEADER_MAGIC 0x99A3E7D6
 #define DMM_UNASSIGNED_REGION NULL
+#define DMM_HEADER_FLAG_TEST (1 << 31)
 
 typedef struct dmm_malloc_header_s {
     uint32_t magic;
     size_t size;
     size_t used; // A bit space-inefficient, but means we only require one type.
+    uint32_t flags; // Currently only used for tests
     void *data;
     struct dmm_malloc_header_s *next;
 } DMM_MallocHeader;

--- a/src/main.c
+++ b/src/main.c
@@ -8,35 +8,35 @@
 #include "header.h"
 #include "instance.h"
 
-DMM_MallocHeader *global_instance = DMM_UNASSIGNED_REGION;
+DMM_MallocHeader *dmm_global_instance = DMM_UNASSIGNED_REGION;
 
 void dmm_add_memory_region(void *start, size_t length)
 {
-    void *result = dmm_instance_add_memory_region(global_instance, start, length);
+    void *result = dmm_instance_add_memory_region(dmm_global_instance, start, length);
 
-    if (global_instance == DMM_UNASSIGNED_REGION || global_instance == NULL) {
+    if (dmm_global_instance == DMM_UNASSIGNED_REGION || dmm_global_instance == NULL) {
         if (result != DMM_UNASSIGNED_REGION && result != NULL) {
-            global_instance = result;
+            dmm_global_instance = result;
         }
     }
 }
 
 DMM_MallocHeader *dmm_get_first_free_chunk(size_t size)
 {
-    return dmm_instance_get_first_free_chunk(global_instance, size);
+    return dmm_instance_get_first_free_chunk(dmm_global_instance, size);
 }
 
 void *dmm_malloc(size_t size)
 {
-    return dmm_instance_malloc(global_instance, size);
+    return dmm_instance_malloc(dmm_global_instance, size);
 }
 
 void dmm_free(void *ptr)
 {
-    dmm_instance_free(global_instance, ptr);
+    dmm_instance_free(dmm_global_instance, ptr);
 }
 
 void *dmm_realloc(void *ptr, size_t size)
 {
-    return dmm_instance_realloc(global_instance, ptr, size);
+    return dmm_instance_realloc(dmm_global_instance, ptr, size);
 }

--- a/src/main.h
+++ b/src/main.h
@@ -7,6 +7,8 @@
 #include <stdint.h>
 #include "header.h"
 
+extern DMM_MallocHeader *dmm_global_instance;
+
 typedef void *(DMM_MallocFn)(size_t size);
 typedef void (DMM_FreeFn)(void *ptr);
 typedef void *(DMM_ReallocFn)(void *ptr, size_t size);

--- a/src/main_test.c
+++ b/src/main_test.c
@@ -37,3 +37,55 @@ size_t test_dmm_free_sets_header()
 
     TEST_ASSERTIONS_RETURN();
 }
+
+size_t test_dmm_allocate_the_universe()
+{
+    DMM_MallocHeader *header;
+
+    // Allocate everything
+    while (1) {
+        void *region = dmm_malloc(ALLOCATE_THE_UNIVERSE_CHUNK_SIZE);
+        if (region == NULL) {
+            break;
+        }
+
+        header = ((DMM_MallocHeader*)region) - 1;
+        header->flags = DMM_HEADER_FLAG_TEST;
+    }
+
+    // Check that all the allocations with the test flag set are of the size
+    // we expect them to be
+    header = dmm_global_instance;
+    while (1) {
+        if (header == NULL) {
+            break;
+        }
+
+        if ((header->flags & DMM_HEADER_FLAG_TEST) == 1) {
+            if (header->size != (ALLOCATE_THE_UNIVERSE_CHUNK_SIZE - sizeof(DMM_MallocHeader))) {
+                TEST_RETURN(TEST_FAILURE, "An allocated test chunk was not of the expected size.");
+            }
+        }
+
+        header = header->next;
+    }
+
+    // Free all the test allocations
+    header = dmm_global_instance;
+    while (1) {
+        if (header == NULL) {
+            break;
+        }
+
+        // Save the value of header->next in case the header disappears when we
+        // free() the region (when DMM actually merges free regions)
+        DMM_MallocHeader *next = header->next;
+        if ((header->flags & DMM_HEADER_FLAG_TEST) == 1) {
+            dmm_free(header->data);
+        }
+
+        header = next;
+    }
+
+    TEST_RETURN(TEST_SUCCESS, "Allocating the universe test passed.");
+}

--- a/src/main_test.c
+++ b/src/main_test.c
@@ -81,6 +81,7 @@ size_t test_dmm_allocate_the_universe()
         // free() the region (when DMM actually merges free regions)
         DMM_MallocHeader *next = header->next;
         if ((header->flags & DMM_HEADER_FLAG_TEST) == 1) {
+            header->flags = 0;
             dmm_free(header->data);
         }
 

--- a/src/main_test.h
+++ b/src/main_test.h
@@ -5,7 +5,10 @@
 #include <dmm.h>
 #include "main.h"
 
+#define ALLOCATE_THE_UNIVERSE_CHUNK_SIZE (1024 * 1024) // 1M
+
 size_t test_dmm_malloc();
 size_t test_dmm_free_sets_header();
+size_t test_dmm_allocate_the_universe();
 
 #endif

--- a/src/test.c
+++ b/src/test.c
@@ -9,6 +9,7 @@ void add_dmm_tests()
     // Global instance tests
     TEST(dmm_malloc);
     TEST(dmm_free_sets_header);
+    TEST(dmm_allocate_the_universe);
 
     // Local instance tests
     TEST(dmm_instance_add_region);


### PR DESCRIPTION
Currently does this in 1M blocks, but that can be adjusted (it's in the header file). This adds a `flags` field to `DMM_MallocHeader`, which is used as a quick-and-dirty way of keeping track of which regions were allocated by this test so it can free() them.

Closes #9.

