### PR TITLE
Add sbuild.toml for sapphire builds

### DIFF
--- a/sbuild.toml
+++ b/sbuild.toml
@@ -1,0 +1,8 @@
+library_root = true
+name = "dmm"
+libtype = "C"
+
+object_remove_globs = []
+ignore_source_regex = [
+  "(^|_)test.c$"
+]


### PR DESCRIPTION
This adds a `sbuild.toml` to enable compiling as part of the [sapphire](https://github.com/0x52a1/sapphire) build process.