### PR TITLE
[main_test] Fix `if` condition always being false.

### DIFF
--- a/src/main_test.c
+++ b/src/main_test.c
@@ -81,7 +81,7 @@ void test_dmm_allocate_the_universe()
         // Save the value of header->next in case the header disappears when we
         // free() the region (when DMM actually merges free regions)
         DMM_MallocHeader *next = header->next;
-        if ((header->flags & DMM_HEADER_FLAG_TEST) == 1) {
+        if ((header->flags & DMM_HEADER_FLAG_TEST) != 0) {
             header->flags = 0;
             dmm_free(header->data);
         }


### PR DESCRIPTION
This is because the result of `header->flags & ((size_t)1 << 31))` is either `0` or `(size_t)1 << 31`, never `1`.

Fixes #25.